### PR TITLE
JSON スキーマの追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ flask = "^2.1.2"
 sphinx = "<4.4.0"  # to avoid confliction of `importlib-metadata`.
 sphinx-intl = "^2.0.1"
 codecov = "^2.1.12"
+jsonschema = "^4.21.1"
 
 [tool.pytest.ini_options]
 testpaths = ["preacher", "tests"]

--- a/validator/preacher.schema.json
+++ b/validator/preacher.schema.json
@@ -1,0 +1,335 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "title": "JSON Schema for Preacher Scenario YAML",
+    "description": "Preacher シナリオの YAML のスキーマです",
+    "type": "object",
+    "$ref": "#/definitions/scenario",
+    "definitions": {
+        "scenario": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "cases": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/case"
+                        }, {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/case"
+                            }
+                        }
+                    ]
+                },
+                "subscenarios": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/yamlTag"
+                        }, {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/scenario"
+                            }
+                        }
+                    ]
+                },
+                "ordered": {
+                    "type": "boolean"
+                },
+                "default": {
+                    "$ref": "#/definitions/case"
+                },
+                "when": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/description"
+                        }, {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/description"
+                            }
+                        }
+                    ]
+                },
+                "parameters": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/yamlTag"
+                        }, {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/parameter"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "case": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "request": {
+                    "$ref": "#/definitions/request"
+                },
+                "response": {
+                    "$ref": "#/definitions/responseDescription"
+                }
+            },
+            "enabled": {
+                "type": "boolean"
+            },
+            "when": {
+                "$ref": "#/definitions/description"
+            },
+            "wait": {
+                "$ref": "#/definitions/datetime"
+            }
+        },
+        "request": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/yamlTag"
+                },{
+                    "type": "string"
+                },{
+                    "type": "object",
+                    "properties": {
+                        "method": {
+                            "type": "string",
+                            "enum": ["GET", "POST", "PUT", "DELETE"]
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "params": {
+                            "$ref": "#/definitions/urlParameters"
+                        },
+                        "body": {
+                            "$ref": "#/definitions/requestBody"
+                        }
+                    }
+                }
+            ]
+        },
+        "urlParameters": {
+            "type": ["string", "object"],
+            "additionalProperties": {
+                "type": ["string", "number", "boolean", "array"]
+            }
+        },
+        "requestBody": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["urlencoded", "json"]
+                },
+                "data": {
+                    "type": ["string", "object"]
+                }
+            }
+        },
+        "responseDescription": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "status_code": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        }, {
+                            "$ref": "#/definitions/matcher"
+                        }, {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/matcher"
+                            }
+                        }
+                    ]
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/description"
+                    }
+                },
+                "body": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/description"
+                        },{
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/description"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "description": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["describe"],
+            "properties": {
+                "describe": {
+                    "$ref": "#/definitions/extraction"
+                },
+                "should": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/matcher"
+                        },{
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/matcher"
+                            }
+                        }
+                    ]
+                },
+                "as": {
+                    "type": "string"
+                }
+            }
+        },
+        "extraction": {
+            "anyOf": [
+                {
+                    "type": "string"
+                }, {
+                    "type": "object",
+                    "properties": {
+                        "jq": {
+                            "type": "string"
+                        },
+                        "xpath": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "multiple": {
+                            "type": "boolean"
+                        },
+                        "cast_to": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "matcher": {
+            "additionalProperties": false,
+            "maxProperties": 1,
+            "type": ["object", "string", "number", "boolean"],
+            "properties": {
+                "equal": {
+                    "type": ["string", "number", "boolean", "array", "object"]
+                },
+                "have_length": {
+                    "type": "number"
+                },
+                "be_greater_than": {
+                    "type": "number"
+                },
+                "be_greater_than_or_equal_to": {
+                    "type": "number"
+                },
+                "be_less_than": {
+                    "type": "number"
+                },
+                "be_less_than_or_equal_to": {
+                    "type": "number"
+                },
+                "contain_string": {
+                    "type": "string"
+                },
+                "start_with": {
+                    "type": "string"
+                },
+                "end_with": {
+                    "type": "string"
+                },
+                "match_regexp": {
+                    "type": "string"
+                },
+                "be_before": {
+                    "$ref": "#/definitions/datetime"
+                },
+                "be_after": {
+                    "$ref": "#/definitions/datetime"
+                },
+                "have_item": {
+                    "$ref": "#/definitions/matcher"
+                },
+                "have_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/matcher"
+                    }
+                },
+                "contain_exactly": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/matcher"
+                    }
+                },
+                "contain_in_any_order": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/matcher"
+                    }
+                },
+                "not": {
+                    "$ref": "#/definitions/matcher"
+                },
+                "all_of": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/matcher"
+                    }
+                },
+                "any_of": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/matcher"
+                    }
+                }
+            }
+        },
+        "parameter": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/yamlTag"
+                }, {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "args": {
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        },
+        "datetime": {
+            "type": "string"
+        },
+        "yamlTag": {
+            "type": "string",
+            "pattern": "^!(argument|include|context) .*"
+        }
+    }
+}

--- a/validator/schema_validator.py
+++ b/validator/schema_validator.py
@@ -1,0 +1,57 @@
+import json
+import argparse
+import glob
+import os
+
+from jsonschema import validate, exceptions
+import yaml
+
+## python schema_validator.py --schemafile preacher.schema.json '../test-case/**/*.yml'
+
+
+# 本家 Preacher のシナリオのパーサに解釈させると一部の項目がオブジェクトになるため独自に丸めている
+# タグを文字列扱いする。intelliJ での挙動に合わせる
+for tag in ['argument', 'include', 'context']:
+    yaml.SafeLoader.add_constructor(f'!{tag}', lambda loader, node: f'!{tag} {loader.construct_scalar(node)}')
+# !relative_datetime は子要素に関わらず無理やり文字列にして intelliJ での挙動に合わせる
+yaml.SafeLoader.add_constructor('!relative_datetime', lambda loader, node: '!relative_datetime')
+
+# 日付形式の文字列を文字列に解釈する
+yaml.SafeLoader.add_constructor('tag:yaml.org,2002:timestamp', lambda loader, node: loader.construct_scalar(node))
+    
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--schemafile', required=True, help='JSON Schema のスキーマファイル')
+    parser.add_argument('filepath', help='検証したい yaml ファイルパス。ワイルドカード利用の場合はシングルクォートで囲む')
+    args = parser.parse_args()
+
+    exit_status = 0
+
+    with open(args.schemafile) as f:
+        schema = json.load(f)
+
+    for path in glob.glob(os.path.expanduser(args.filepath), recursive=True):
+        try:
+            with open(path) as f:
+                docs = yaml.safe_load_all(f)
+                for doc in docs:
+                    try:
+                        validate(instance=doc, schema=schema)
+                        # print(f'OK: {path}')
+                    except exceptions.ValidationError as e:
+                        print(f'NG: {path}')
+                        print(e.json_path)
+                        print(e.message)
+                        exit_status = 1
+        except Exception as e:
+            print(f'NG: {path}')
+            print(e)
+            exit_status = 1
+    
+    return exit_status
+
+if __name__ == '__main__':
+    exit_status = main()
+    exit(exit_status)
+


### PR DESCRIPTION
[JSON Schema](https://json-schema.org/) でシナリオのバリデーションができるように設定ファイルを追加しました。
※ **JSON** Schema という名称ですが、intelliJ や VSCode で YAML のバリデーションにも利用できるものです。

また、CI 上でもバリデーション結果を確認したかったため書いたスクリプトも合わせて追加しています。
自分が試したいくつかのコマンドラインツールでは YAML の読み込みに失敗しうまくバリデーションできなかったため、YAML の読み込みに細工を加えるためにスクリプトにしています。
特定プロダクトのテストケースに依存したものではないためプルリクに含めさせていただきました。
ただ、あまり出来が良くないかもしれないので取り込み時にはカットしていただくとか書き直してしまっていただくとかでも構いません。

お手数をおかけいたしますがご検討の程よろしくお願いいたします。